### PR TITLE
Fix modem port detection

### DIFF
--- a/unlocker.py
+++ b/unlocker.py
@@ -75,6 +75,7 @@ def identifyPort():
 		print "Testing port " + p
 		ser = serial.Serial(port = p,
 				timeout = 15)
+		ser.write('AT\r\n')
 		activity = ser.read(5)
 		if activity == '':
 			print "\tNo activity\n"


### PR DESCRIPTION
I had to add this to get it to work, without all `/dev/ttyUSB*` devices would be giving "No activity".

IMHO this should be more robust because not all devices report stuff without beeing asked.

Thanks a lot for this tool, much better than all the dubious websites.
